### PR TITLE
Implement hacky fix for delete, comment submission no longer reloads whole page

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -34,17 +34,10 @@ import javax.servlet.http.HttpServletResponse;
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
-  private ArrayList<String> comments;
-
-  @Override
-  public void init() {
-    comments = new ArrayList<>();
-  }
-
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    System.out.println("Initiating Query. Size: " + comments.size());
-    comments.clear();
+    System.out.println("Initiating Query.");
+    ArrayList<String> comments = new ArrayList<String>();
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     Query query = new Query("Comment");
@@ -59,12 +52,12 @@ public class DataServlet extends HttpServlet {
     int displayedComments = tryParseInt(maxCommentParam);
 
     if (displayedComments >= 0)
-      writeGetResponse(response, displayedComments);
+      writeGetResponse(response, comments, displayedComments);
   }
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    System.out.println("Initiating post. Size before: " + comments.size());
+    System.out.println("Initiating post.");
     String commentBody = request.getParameter("comment-body");
 
     Entity commentEntity = new Entity("Comment");
@@ -86,8 +79,8 @@ public class DataServlet extends HttpServlet {
     return num;
   }
 
-  private void writeGetResponse(HttpServletResponse response, int displayedComments)
-      throws IOException {
+  private void writeGetResponse(HttpServletResponse response, ArrayList<String> comments,
+      int displayedComments) throws IOException {
     if (displayedComments > comments.size())
       displayedComments = comments.size();
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -37,22 +37,15 @@ public class DeleteDataServlet extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     System.out.println("Comment delete initiated.");
+
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Query query = new Query("Comment");
     PreparedQuery results = datastore.prepare(query);
-    ArrayList<Key> keys = new ArrayList<Key>();
+
     for (Entity entity : results.asIterable()) {
-      keys.add(entity.getKey());
+      datastore.delete(entity.getKey());
     }
-    Transaction txn = datastore.beginTransaction(TransactionOptions.Builder.withXG(true));
-    try {
-      datastore.delete(txn, keys);
-      txn.commit();
-    } finally {
-      if (txn.isActive()) {
-        txn.rollback();
-      }
-    }
+
     System.out.println("Comment delete finished.");
   }
 }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -30,9 +30,11 @@
       <div id="avatar-container"></div>
 
       <p>Leave a Comment:</p>
-      <input type="text" id="comment-body" />
-      <button type="button" onclick="postComment()">Submit</button>
-      <br /><br />
+      <form onsubmit="postComment(event)">
+        <input type="text" id="comment-body" />
+        <button type="submit">Submit</button>
+        <br /><br />
+      </form>
 
       <p>Select number of comments to display:</p>
       <select onchange="getComments()" id="max-comment-select">
@@ -46,7 +48,7 @@
       <ul id="comment-list"></ul>
 
       <br />
-      <button type="button" onclick="deleteComments()">Delete All</button>
+      <button type="button" onclick="deleteCommentsTwice()">Delete All</button>
       <br />
     </div>
   </body>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -58,7 +58,7 @@ function addRandomLine() {  // eslint-disable-line no-unused-vars
   container.innerText = line;
 }
 
-function getComments() {  // eslint-disable-line no-unused-vars
+function getComments() {
   const maxComments = document.getElementById('max-comment-select').value;
   fetch('/data?max-comments=' + maxComments)
       .then((response) => response.json())
@@ -84,14 +84,26 @@ function createListElement(text) {
   return liElement;
 }
 
-function postComment() {  // eslint-disable-line no-unused-vars
+function postComment(e) {  // eslint-disable-line no-unused-vars
   const commentBody = document.getElementById('comment-body').value;
   const request =
       new Request('/data?comment-body=' + commentBody, {method: 'POST'});
   fetch(request).then(() => getComments());
+
+  // Clear input form
+  document.getElementById('comment-body').value = '';
+
+  // cancel default event action (page refresh)
+  e = e || window.event;
+  e.preventDefault();
 }
 
-function deleteComments() {  // eslint-disable-line no-unused-vars
+function deleteCommentsTwice() {  // eslint-disable-line no-unused-vars
+  deleteComments();
+  deleteComments();
+}
+
+function deleteComments() {
   const request = new Request('/delete-data', {method: 'POST'});
   fetch(request).then(() => getComments());
 }


### PR DESCRIPTION
I implemented all the changes suggested in the last pull request.

Also, after talking to Hari, I applied a kinda hacky fix for the comment delete issue that invokes the deleteComment() js method twice. This seems to give better reliability of updates to the page being reflected accurately.